### PR TITLE
Add a couple fixes to get android build working.

### DIFF
--- a/modules/tracktion_engine/tracktion_engine.h
+++ b/modules/tracktion_engine/tracktion_engine.h
@@ -34,7 +34,8 @@
 #pragma once
 #define TRACKTION_ENGINE_H_INCLUDED
 
-#if ! JUCE_MODAL_LOOPS_PERMITTED
+// Android does not support modal loops.
+#if ! JUCE_MODAL_LOOPS_PERMITTED && ! JUCE_ANDROID
  #error "You must define JUCE_MODAL_LOOPS_PERMITTED=1 to use Tracktion Engine"
 #endif
 


### PR DESCRIPTION
1) Allow android to build without modal loops since they aren't supported on Android. See https://forum.juce.com/t/how-can-i-change-juce-modal-loops-permitted-1-to-use-tracktion-engine/48460.
2) Remove an assertion about unsupported audio device types because it doesn't actually matter if a new type isn't yet supported by tracktion. We only care about bluetooth, speaker, wired headphones, etc. for now anyway. NOTE: This fix is in JUCE, but I need to bump the juce dep to get it