### PR TITLE
Add cpu overload detection

### DIFF
--- a/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
+++ b/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
@@ -1124,7 +1124,6 @@ void DeviceManager::audioDeviceIOCallbackInternal (const float** inputChannelDat
             currentCpuUsage = std::min (0.9, currentCpuUsage * 0.99);
 
             numCpuOverloads++;
-            std::cout << "Audio Engine: CPU OVERLOAD!\n";
         }
         else
         {

--- a/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
+++ b/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
@@ -1122,10 +1122,13 @@ void DeviceManager::audioDeviceIOCallbackInternal (const float** inputChannelDat
                     juce::FloatVectorOperations::clear (dest, numSamples);
 
             currentCpuUsage = std::min (0.9, currentCpuUsage * 0.99);
+
+            numCpuOverloads++;
+            std::cout << "Audio Engine: CPU OVERLOAD!\n";
         }
         else
         {
-            broadcastStreamTimeToMidiDevices (streamTime + outputLatencyTime);
+            broadcastStreamTimeToMidiDevices (  streamTime + outputLatencyTime);
             EditTimeRange blockStreamTime;
 
             {

--- a/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
+++ b/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
@@ -1128,7 +1128,7 @@ void DeviceManager::audioDeviceIOCallbackInternal (const float** inputChannelDat
         }
         else
         {
-            broadcastStreamTimeToMidiDevices (  streamTime + outputLatencyTime);
+            broadcastStreamTimeToMidiDevices (streamTime + outputLatencyTime);
             EditTimeRange blockStreamTime;
 
             {

--- a/modules/tracktion_engine/playback/tracktion_DeviceManager.h
+++ b/modules/tracktion_engine/playback/tracktion_DeviceManager.h
@@ -182,6 +182,8 @@ public:
 
     Engine& engine;
 
+    int getNumCpuOverloads() { return numCpuOverloads; }
+
 private:
     struct WaveDeviceList;
     struct ContextDeviceClearer;
@@ -189,6 +191,7 @@ private:
     bool sendMidiTimecode = false;
 
     std::atomic<double> currentCpuUsage { 0 }, streamTime { 0 }, cpuLimitBeforeMuting { 0.98 };
+    std::atomic<int> numCpuOverloads { 0 };
     double currentLatencyMs = 0, outputLatencyTime = 0, currentSampleRate = 0;
     juce::Array<EditPlaybackContext*> contextsToRestart;
 

--- a/modules/tracktion_engine/playback/tracktion_DeviceManager.h
+++ b/modules/tracktion_engine/playback/tracktion_DeviceManager.h
@@ -184,6 +184,8 @@ public:
 
     int getNumCpuOverloads() { return numCpuOverloads; }
 
+    void resetNumCpuOverloads() { numCpuOverloads = 0; }
+
 private:
     struct WaveDeviceList;
     struct ContextDeviceClearer;


### PR DESCRIPTION
Adds a basic counter to the engine, and the getter returns the total number of overloads since instanciation. 

To make this a meaningful stat, it will need to be weighted by the amount of time in the studio. 

E.g. 
numOverloadsPerMinute = numOverloads / timeInStudioMinutes